### PR TITLE
use the right line endings

### DIFF
--- a/tests/HTTP/RequestTest.php
+++ b/tests/HTTP/RequestTest.php
@@ -125,12 +125,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         $request = new Request('PUT', '/foo/bar', ['Content-Type' => 'text/xml']);
         $request->setBody('foo');
 
-        $expected = <<<HI
-PUT /foo/bar HTTP/1.1\r
-Content-Type: text/xml\r
-\r
-foo
-HI;
+        $expected = "PUT /foo/bar HTTP/1.1\r\n"
+                  . "Content-Type: text/xml\r\n"
+                  . "\r\n"
+                  . "foo";
         $this->assertEquals($expected, (string)$request);
 
     }
@@ -140,13 +138,11 @@ HI;
         $request = new Request('PUT', '/foo/bar', ['Content-Type' => 'text/xml', 'Authorization' => 'Basic foobar']);
         $request->setBody('foo');
 
-        $expected = <<<HI
-PUT /foo/bar HTTP/1.1\r
-Content-Type: text/xml\r
-Authorization: Basic REDACTED\r
-\r
-foo
-HI;
+        $expected = "PUT /foo/bar HTTP/1.1\r\n"
+                  . "Content-Type: text/xml\r\n"
+                  . "Authorization: Basic REDACTED\r\n"
+                  . "\r\n"
+                  . "foo";
         $this->assertEquals($expected, (string)$request);
 
     }

--- a/tests/HTTP/ResponseTest.php
+++ b/tests/HTTP/ResponseTest.php
@@ -35,12 +35,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
         $response = new Response(200, ['Content-Type' => 'text/xml']);
         $response->setBody('foo');
 
-        $expected = <<<HI
-HTTP/1.1 200 OK\r
-Content-Type: text/xml\r
-\r
-foo
-HI;
+        $expected = "HTTP/1.1 200 OK\r\n"
+                  . "Content-Type: text/xml\r\n"
+                  . "\r\n"
+                  . "foo";
         $this->assertEquals($expected, (string)$response);
 
     }


### PR DESCRIPTION
This fixes 3 failing tests on Windows (10).

Or should `$eol` be `\r\n`?