### PR TITLE
Sending encoding="UTF-8" on basic auth challenges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+4.2.4 (????-??-??)
+------------------
+
+* #69: Sending `charset="UTF-8"` on Basic authentication challenges per
+  [rfc7617][rfc7617].
+
+
 4.2.3 (2017-06-12)
 ------------------
 
@@ -11,7 +18,6 @@ ChangeLog
 ------------------
 
 * #72: Handling clients that send invalid `Content-Length` headers.
-
 
 4.2.1 (2016-01-06)
 ------------------
@@ -259,4 +265,5 @@ Before 2.0.0, this package was built-into SabreDAV, where it first appeared in
 January 2009.
 
 [psr-http]: https://github.com/php-fig/fig-standards/blob/master/proposed/http-message.md
-[rfc-7240]: http://tools.ietf.org/html/rfc7240
+[rfc7240]: http://tools.ietf.org/html/rfc7240
+[rfc7617]: https://tools.ietf.org/html/rfc7617

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -55,7 +55,7 @@ class Basic extends AbstractAuth {
      */
     function requireLogin() {
 
-        $this->response->addHeader('WWW-Authenticate', 'Basic realm="' . $this->realm . '"');
+        $this->response->addHeader('WWW-Authenticate', 'Basic realm="' . $this->realm . '", charset="UTF-8"');
         $this->response->setStatus(401);
 
     }

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -77,12 +77,12 @@ class Sapi {
             if (is_resource($body) && get_resource_type($body) == 'stream') {
                 if (PHP_INT_SIZE !== 4){
                     // use the dedicated function on 64 Bit systems
-                    stream_copy_to_stream($body, $output, $contentLength);  
+                    stream_copy_to_stream($body, $output, $contentLength);
                 } else {
                     // workaround for 32 Bit systems to avoid stream_copy_to_stream
                     while (!feof($body)) {
-                        fwrite($output, fread($body, 8192));    
-                    }   
+                        fwrite($output, fread($body, 8192));
+                    }
                 }
             } else {
                 fwrite($output, $body, $contentLength);

--- a/tests/HTTP/Auth/BasicTest.php
+++ b/tests/HTTP/Auth/BasicTest.php
@@ -61,7 +61,7 @@ class BasicTest extends \PHPUnit_Framework_TestCase {
 
         $basic->requireLogin();
 
-        $this->assertEquals('Basic realm="Dagger"', $response->getHeader('WWW-Authenticate'));
+        $this->assertEquals('Basic realm="Dagger", charset="UTF-8"', $response->getHeader('WWW-Authenticate'));
         $this->assertEquals(401, $response->getStatus());
 
     }


### PR DESCRIPTION
Fixes #69. Thanks for the suggestion @rfc2822