### PR TITLE
README.md instructions should mention 5.0.0 instead of 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ or edit a `composer.json` file, and make sure it contains something like this:
 ```json
 {
     "require" : {
-        "sabre/http" : "~3.0.0"
+        "sabre/http" : "~5.0.0"
     }
 }
 ```


### PR DESCRIPTION
We don't have a 5.0.0 branch, so didn't update build status.