### PR TITLE
Significantly improve file download speed by enabling mmap based…

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -89,9 +89,28 @@ class Sapi
         if (null !== $contentLength) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && 'stream' == get_resource_type($body)) {
-                if (PHP_INT_SIZE !== 4) {
+                if (PHP_INT_SIZE > 4) {
                     // use the dedicated function on 64 Bit systems
-                    stream_copy_to_stream($body, $output, (int) $contentLength);
+                    // a workaround to make PHP more possible to use mmap based copy, see https://github.com/sabre-io/http/pull/119
+                    $left = (int) $contentLength;
+                    // copy with 4MiB chunks
+                    $chunk_size = 4 * 1024 * 1024;
+                    stream_set_chunk_size($output, $chunk_size);
+                    // If this is a partial response, flush the beginning bytes until the first position that is a multiple of the page size.
+                    $contentRange = $response->getHeader('Content-Range');
+                    // Matching "Content-Range: bytes 1234-5678/7890"
+                    if ($contentRange !== null && preg_match('/^bytes\s([0-9]*)-([0-9]*)\//i', $contentRange, $matches) && $matches[1] !== '') {
+                        // 4kB should be the default page size on most architectures
+                        $pageSize = 4096;
+                        $offset = (int) $matches[1];
+                        $delta = ($offset % $pageSize) > 0 ? ($pageSize - $offset % $pageSize) : 0;
+                        if ($delta > 0) {
+                            $left -= stream_copy_to_stream($body, $output, $delta);
+                        }
+                    }
+                    while ($left > 0) {
+                        $left -= stream_copy_to_stream($body, $output, min($left, $chunk_size));
+                    }
                 } else {
                     // workaround for 32 Bit systems to avoid stream_copy_to_stream
                     while (!feof($body)) {

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -99,7 +99,7 @@ class Sapi
                     // If this is a partial response, flush the beginning bytes until the first position that is a multiple of the page size.
                     $contentRange = $response->getHeader('Content-Range');
                     // Matching "Content-Range: bytes 1234-5678/7890"
-                    if ($contentRange !== null && preg_match('/^bytes\s([0-9]*)-([0-9]*)\//i', $contentRange, $matches) && $matches[1] !== '') {
+                    if (null !== $contentRange && preg_match('/^bytes\s([0-9]*)-([0-9]*)\//i', $contentRange, $matches) && '' !== $matches[1]) {
                         // 4kB should be the default page size on most architectures
                         $pageSize = 4096;
                         $offset = (int) $matches[1];


### PR DESCRIPTION
…am_copy_to_stream

## Background
I run a Nextcloud server on a VM (1 CPU core, 1G RAM, 10Gbps virtio network, PHP 7.2.10) on a SSD storage. Directly reading a large file (let’s say 10GiB) on that server will get a read speed around 540-550 MiB/s. However the download speed with webdav is only about 240-260 MiB/s.

I tried replacing the `stream_copy_to_stream` function call in Sapi.php with `fpassthru`, getting a significantly performance boost (440-470 MiB/s). It seems to me that the performance bottleneck is `stream_copy_to_stream`.

## Root Cause
I started investigating this problem by digging into source code of the PHP internal functions, then finally figured out what was going wrong.

`stream_copy_to_stream` tries to mmap the source file. If failed, fallback to the manual copy way:
<https://github.com/php/php-src/blob/00d2b7a3d28d29383450fc2607c7d4fb91d57a4a/main/streams/streams.c#L1467>.
But PHP refuses to mmap a file larger than 4MiB according to <https://github.com/php/php-src/blob/623911f993f39ebbe75abe2771fc89faf6b15b9b/main/streams/mmap.c#L34 >.

## Solution (workaround?)
So, I started to modify the code: Instead of asking `stream_copy_to_stream` to copy the whole to-be-downloaded file, calling `stream_copy_to_stream` in a loop for each 4MiB chunk of the file.

After applying this PR, I got full download speed about just like reading that file locally (even faster than  `fpassthru`).

I can’t wait to share my patch because I am really happy with the optimization! Please help me review and tell me if this is the right way.