### PR TITLE
fix "Trying to access array offset on value of type bool" in 7.4

### DIFF
--- a/lib/Auth/Digest.php
+++ b/lib/Auth/Digest.php
@@ -113,7 +113,7 @@ class Digest extends AbstractAuth
      */
     public function getUsername()
     {
-        return $this->digestParts['username'];
+        return $this->digestParts['username'] ?? null;
     }
 
     /**
@@ -121,6 +121,10 @@ class Digest extends AbstractAuth
      */
     protected function validate(): bool
     {
+        if (!is_array($this->digestParts)) {
+            return false;
+        }
+
         $A2 = $this->request->getMethod().':'.$this->digestParts['uri'];
 
         if ('auth-int' === $this->digestParts['qop']) {


### PR DESCRIPTION
Without:

```
1) Sabre\HTTP\Auth\DigestTest::testInvalidDigest2
Trying to access array offset on value of type bool

/work/GIT/sabre-http/lib/Auth/Digest.php:124
/work/GIT/sabre-http/lib/Auth/Digest.php:94
/work/GIT/sabre-http/tests/HTTP/Auth/DigestTest.php:99

```

Also see https://github.com/sabre-io/dav/pull/1187