### PR TITLE
Fix short Content-Range download

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -105,7 +105,7 @@ class Sapi
                         $offset = (int) $matches[1];
                         $delta = ($offset % $pageSize) > 0 ? ($pageSize - $offset % $pageSize) : 0;
                         if ($delta > 0) {
-                            $left -= stream_copy_to_stream($body, $output, $delta);
+                            $left -= stream_copy_to_stream($body, $output, min($delta, $left));
                         }
                     }
                     while ($left > 0) {


### PR DESCRIPTION
Issue #134 

The code was sending the fragment of data up to the next 4096-byte boundary, even if that exceeded the actual amount of content requested.