### PR TITLE
Update to PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ composer.lock
 # Tests
 tests/cov/
 
+# phpunit cache
+.phpunit.result.cache
+
 # Composer binaries
 bin/phpunit*
 bin/phpcs*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 sudo: required
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://github.com/fruux/sabre-http",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php"          : "^7.0",
+        "php"          : "^7.2",
         "ext-mbstring" : "*",
         "ext-ctype"    : "*",
         "ext-curl"     : "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^6.0 || ^7.0 || ^8.0"
+        "phpunit/phpunit" : "^7.0 || ^8.0"
     },
     "suggest" : {
         "ext-curl" : " to make http requests with the Client class"

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,11 @@
             "Sabre\\HTTP\\" : "lib/"
         }
     },
+    "autoload-dev" : {
+        "psr-4" : {
+            "Sabre\\HTTP\\" : "tests/HTTP"
+        }
+    },
     "config" : {
         "bin-dir" : "bin/"
     }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.0"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^6.0 || ^7.0"
+        "phpunit/phpunit" : "^6.0 || ^7.0 || ^8.0"
     },
     "suggest" : {
         "ext-curl" : " to make http requests with the Client class"

--- a/tests/HTTP/Auth/AWSTest.php
+++ b/tests/HTTP/Auth/AWSTest.php
@@ -26,7 +26,7 @@ class AWSTest extends \PHPUnit\Framework\TestCase
 
     const REALM = 'SabreDAV unittest';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = new Response();
         $this->request = new Request('GET', '/');

--- a/tests/HTTP/Auth/DigestTest.php
+++ b/tests/HTTP/Auth/DigestTest.php
@@ -28,7 +28,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
 
     const REALM = 'SabreDAV unittest';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = new Response();
         $this->request = new Request('GET', '/');

--- a/tests/HTTP/MessageDecoratorTest.php
+++ b/tests/HTTP/MessageDecoratorTest.php
@@ -9,7 +9,7 @@ class MessageDecoratorTest extends \PHPUnit\Framework\TestCase
     protected $inner;
     protected $outer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->inner = new Request('GET', '/');
         $this->outer = new RequestDecorator($this->inner);

--- a/tests/HTTP/RequestDecoratorTest.php
+++ b/tests/HTTP/RequestDecoratorTest.php
@@ -9,7 +9,7 @@ class RequestDecoratorTest extends \PHPUnit\Framework\TestCase
     protected $inner;
     protected $outer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->inner = new Request('GET', '/');
         $this->outer = new RequestDecorator($this->inner);

--- a/tests/HTTP/RequestTest.php
+++ b/tests/HTTP/RequestTest.php
@@ -101,11 +101,9 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('', $request->getPath());
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testGetPathOutsideBaseUrl()
     {
+        $this->expectException('LogicException');
         $request = new Request('GET', '/bar/');
         $request->setBaseUrl('/foo/');
 

--- a/tests/HTTP/ResponseDecoratorTest.php
+++ b/tests/HTTP/ResponseDecoratorTest.php
@@ -9,7 +9,7 @@ class ResponseDecoratorTest extends \PHPUnit\Framework\TestCase
     protected $inner;
     protected $outer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->inner = new Response();
         $this->outer = new ResponseDecorator($this->inner);

--- a/tests/HTTP/ResponseTest.php
+++ b/tests/HTTP/ResponseTest.php
@@ -21,11 +21,9 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Where\'s my money?', $response->getStatusText());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidStatus()
     {
+        $this->expectException('InvalidArgumentException');
         $response = new Response(1000);
     }
 


### PR DESCRIPTION
Updated from PHPUnit version 7 -> 8

Codebase changes were needed:
- Updated Composer PHPUnit version to ^8
- Refactored test to work with PHPUnit8
- Added PHPUnit Cache to gitignore

!important: PHPUnit8 requires PHP ^7.2 -> PHP version has to be updated bevor merging.
because of that not all checks are successfull.

//cc @staabm 