### PR TITLE
Put back PHP 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 sudo: required
 php:
+  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://github.com/fruux/sabre-http",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php"          : "^7.2",
+        "php"          : "^7.1",
         "ext-mbstring" : "*",
         "ext-ctype"    : "*",
         "ext-curl"     : "*",


### PR DESCRIPTION
to be consistent with the other repos.

It should be easy to keep supporting PHP 7.1 for a few more months.