### PR TITLE
Fix PHP8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - nightly
 
 env:
   global:
@@ -14,6 +15,8 @@ env:
     - PREFER_LOWEST="--prefer-lowest" REPORT_COVERAGE="FALSE" WITH_COVERAGE=""
 
 matrix:
+  allow_failures:
+    - php: nightly
   include:
     - name: 'PHPStan'
       php: 7.4

--- a/lib/Auth/AbstractAuth.php
+++ b/lib/Auth/AbstractAuth.php
@@ -42,7 +42,7 @@ abstract class AbstractAuth
     /**
      * Creates the object.
      */
-    public function __construct(string $realm = 'SabreTooth', RequestInterface $request, ResponseInterface $response)
+    public function __construct(string $realm, RequestInterface $request, ResponseInterface $response)
     {
         $this->realm = $realm;
         $this->request = $request;


### PR DESCRIPTION
PHP8 triggers these errors:
"Required parameter $request follows optional parameter $realm"
"Required parameter $response follows optional parameter $realm"

As $request and $response are not nullable, $realm parameter should be always set by constructor caller, so removing its default value should not change anything to method behaviour.