### PR TITLE
Fix memory_get_peak_usage assert

### DIFF
--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -212,7 +212,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $response = $client->send($request);
 
         $this->assertEquals(200, $response->getStatus());
-        $this->assertGreaterThan(memory_get_peak_usage(), 40 * pow(1024, 2));
+        $this->assertLessThan(40 * pow(1024, 2), memory_get_peak_usage());
     }
 
     /**

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -212,7 +212,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $response = $client->send($request);
 
         $this->assertEquals(200, $response->getStatus());
-        $this->assertLessThan(40 * pow(1024, 2), memory_get_peak_usage());
+        $this->assertLessThan(60 * pow(1024, 2), memory_get_peak_usage());
     }
 
     /**


### PR DESCRIPTION
1) Change expected and actual to be around the usual way
2) Increase the limit of `memory_get_peak_usage()` from 40MB to 60MB. The actual value seems to now be around 49MB when running with PHPunit 9.4. Maybe PHPunit 9.1,2,3 or 4 did something that caused more memory to be used while running tests.

Fixes #157 

The other option is to remove this sort of run-time memory usage test. I guess there is some history for this, there must have been a bug where lots of memory got allocated/leaked...