### PR TITLE
Test with PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ php:
 
 env:
   global:
+    - RUN_PHPCSFIXER="TRUE"
+    - RUN_PHPUNIT="TRUE"
     - RUN_PHPSTAN="FALSE"
   matrix:
     - PREFER_LOWEST="" REPORT_COVERAGE="TRUE" WITH_COVERAGE="--coverage-clover=coverage.xml"
@@ -15,9 +17,17 @@ env:
 
 matrix:
   include:
+    - name: 'PHP8'
+      dist: focal
+      php: nightly
+      env:
+        - RUN_PHPCSFIXER="FALSE"
+        - REPORT_COVERAGE="FALSE"
     - name: 'PHPStan'
       php: 7.4
       env:
+        - RUN_PHPCSFIXER="FALSE"
+        - RUN_PHPUNIT="FALSE"
         - RUN_PHPSTAN="TRUE"
         - REPORT_COVERAGE="FALSE"
   fast_finish: true
@@ -27,13 +37,14 @@ cache:
         - $HOME/.composer/cache
 
 before_script:
+  - if [ $RUN_PHPCSFIXER == "FALSE" ]; then composer remove --dev friendsofphp/php-cs-fixer; fi
   - composer update $PREFER_LOWEST
   - PHP_BIN=$(phpenv which php)
   - sudo $PHP_BIN -S localhost:80 -t $TRAVIS_BUILD_DIR/tests/www 2>/dev/null &
 
 script:
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
-  - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
+  - if [ $RUN_PHPCSFIXER == "TRUE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
+  - if [ $RUN_PHPUNIT == "TRUE" ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
   - if [ $RUN_PHPSTAN == "TRUE" ]; then composer phpstan; fi
 
 after_success:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage" : "https://github.com/fruux/sabre-http",
     "license" : "BSD-3-Clause",
     "require" : {
-        "php"          : "^7.1",
+        "php"          : "^7.1 || ^8.0",
         "ext-mbstring" : "*",
         "ext-ctype"    : "*",
         "ext-curl"     : "*",

--- a/lib/Auth/AbstractAuth.php
+++ b/lib/Auth/AbstractAuth.php
@@ -42,7 +42,7 @@ abstract class AbstractAuth
     /**
      * Creates the object.
      */
-    public function __construct(string $realm = 'SabreTooth', RequestInterface $request, ResponseInterface $response)
+    public function __construct(string $realm, RequestInterface $request, ResponseInterface $response)
     {
         $this->realm = $realm;
         $this->request = $request;

--- a/lib/Auth/Digest.php
+++ b/lib/Auth/Digest.php
@@ -46,7 +46,7 @@ class Digest extends AbstractAuth
     /**
      * Initializes the object.
      */
-    public function __construct(string $realm = 'SabreTooth', RequestInterface $request, ResponseInterface $response)
+    public function __construct(string $realm, RequestInterface $request, ResponseInterface $response)
     {
         $this->nonce = uniqid();
         $this->opaque = md5($realm);


### PR DESCRIPTION
1) sort out variables in `.travis.yml` for selecting to run php-cs-fixer, phpunit and phpstan
2) Add a matrix entry to run just phpunit on Ubuntu 20.04 "focal" with "nightly" PHP (which is the way to get PHP 8.0 at the moment)
3) When not running php-cs-fixer, explicitly remove it from `composer.json` (because php-cs-fixer does not yet support PHP 8.0, so composer cannot sort out dependencies if we have PHP 8.0 and php-cs-fixer 2.* together)
4) Fix the constructor declarations that have an optional parameter before a required parameter (PHP 8.0 complains about these)