### PR TITLE
Run a test pipeline with Ubuntu 20.04 and PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ env:
 
 matrix:
   include:
+    - name: 'Ubuntu20.04'
+      dist: focal
+      php: 7.4
+      env:
+        - RUN_PHPSTAN="FALSE"
+        - REPORT_COVERAGE="FALSE"
+        - WITH_COVERAGE=""
+        - PREFER_LOWEST=""
     - name: 'PHPStan'
       php: 7.4
       env:


### PR DESCRIPTION
Maybe this is useful to know that the latest Ubuntu 20.04 (which comes with PHP 7.4 by default) works.