### PR TITLE
Optimization of memory usage

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -227,7 +227,7 @@ class Client extends EventEmitter
         do {
             $status = curl_multi_info_read($this->curlMultiHandle, $messagesInQueue);
 
-            if ($status !== false && CURLMSG_DONE === $status['msg']) {
+            if (false !== $status && CURLMSG_DONE === $status['msg']) {
                 $curlHandle = $status['handle'];
                 $handleId = (int) $curlHandle;
                 [$request, $successCallback, $errorCallback, $retryCount] = $this->curlMultiMap[$handleId];
@@ -478,11 +478,7 @@ class Client extends EventEmitter
      */
     protected function parseCurlResponse(array $headerLines, string $body, $curlHandle): array
     {
-        list(
-            $curlInfo,
-            $curlErrNo,
-            $curlErrMsg
-            ) = $this->curlStuff($curlHandle);
+        [$curlInfo, $curlErrNo, $curlErrMsg] = $this->curlStuff($curlHandle);
 
         if ($curlErrNo) {
             return [
@@ -533,11 +529,7 @@ class Client extends EventEmitter
      */
     protected function parseCurlResult(string $response, $curlHandle): array
     {
-        list(
-            $curlInfo,
-            $curlErrNo,
-            $curlErrMsg
-            ) = $this->curlStuff($curlHandle);
+        [$curlInfo, $curlErrNo, $curlErrMsg] = $this->curlStuff($curlHandle);
 
         if ($curlErrNo) {
             return [
@@ -620,6 +612,7 @@ class Client extends EventEmitter
             if (is_callable($userHeaderFunction)) {
                 $userHeaderFunction($curlHandle, $str);
             }
+
             return $this->receiveCurlHeader($curlHandle, $str);
         };
 
@@ -634,7 +627,7 @@ class Client extends EventEmitter
      * This method exists so it can easily be overridden and mocked.
      *
      * @param resource|\CurlHandle $curlHandle
-     * @param bool $returnString If true then returns response content string
+     * @param bool                 $returnString If true then returns response content string
      *
      * @return bool|string
      */
@@ -652,6 +645,7 @@ class Client extends EventEmitter
             return '';
         }
         rewind($this->responseResourcesMap[$handleId]);
+
         return stream_get_contents($this->responseResourcesMap[$handleId]);
     }
 

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -554,7 +554,8 @@ class ClientMock extends Client
                 fwrite($stream, $body);
                 rewind($stream);
             }
-            $this->responseResourcesMap[(int)$curlHandle] = $stream;
+            $this->responseResourcesMap[(int) $curlHandle] = $stream;
+
             return $return;
         }
     }

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -229,7 +229,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 
         $request = new Request('GET', $url);
         $client->sendAsync($request, function (ResponseInterface $response) {
-            $this->assertEquals("foo\n", $response->getBody());
+            $this->assertEquals("foo\n", stream_get_contents($response->getBody()));
             $this->assertEquals(200, $response->getStatus());
             $this->assertEquals(4, $response->getHeader('Content-Length'));
         }, function ($error) use ($request) {
@@ -243,7 +243,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     /**
      * @group ci
      */
-    public function testSendAsynConsecutively()
+    public function testSendAsyncConsecutively()
     {
         $url = $this->getAbsoluteUrl('/foo');
         if (!$url) {
@@ -254,7 +254,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 
         $request = new Request('GET', $url);
         $client->sendAsync($request, function (ResponseInterface $response) {
-            $this->assertEquals("foo\n", $response->getBody());
+            $this->assertEquals("foo\n", stream_get_contents($response->getBody()));
             $this->assertEquals(200, $response->getStatus());
             $this->assertEquals(4, $response->getHeader('Content-Length'));
         }, function ($error) use ($request) {
@@ -265,7 +265,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $url = $this->getAbsoluteUrl('/bar.php');
         $request = new Request('GET', $url);
         $client->sendAsync($request, function (ResponseInterface $response) {
-            $this->assertEquals("bar\n", $response->getBody());
+            $this->assertEquals("bar\n", stream_get_contents($response->getBody()));
             $this->assertEquals(200, $response->getStatus());
             $this->assertEquals('Bar', $response->getHeader('X-Test'));
         }, function ($error) use ($request) {
@@ -459,7 +459,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = new ClientMock();
         $request = new Request('GET', 'http://example.org/');
-        $client->on('curlPrepareAndExec', function (&$return, string &$headers, string &$body) {
+        $client->on('curlExec', function (&$return, string &$headers, string &$body) {
             $return = false;
         });
         $client->on('curlStuff', function (&$return) {
@@ -558,7 +558,7 @@ class ClientMock extends Client
         if (is_null($return)) {
             return parent::curlExec($curlHandle, $returnString);
         } else {
-            $this->parseHeaders($curlHandle, $headers);
+            $this->parseHeadersBlock($curlHandle, $headers);
             $stream = \fopen('php://memory', 'rw+');
             if (strlen($body) > 0) {
                 fwrite($stream, $body);

--- a/tests/www/anysize.php
+++ b/tests/www/anysize.php
@@ -1,0 +1,19 @@
+<?php
+
+$megabytes = $_GET['size'] ?? 1;
+$megabytes = max(1, is_numeric($megabytes) ? (int) $megabytes : 1);
+set_time_limit(0);
+
+header('Content-Length: '.($megabytes * 1024 * 1024));
+header('Content-Type: text/plain');
+
+$generator = static function (int $chunkSize, int $count): Generator {
+    $chunk = str_repeat(' ', $chunkSize);
+    for ($i = 0; $i < $count; ++$i) {
+        yield $i => $chunk;
+    }
+};
+
+foreach ($generator(512 * 1024, $megabytes * 2) as $value) {
+    echo $value;
+}


### PR DESCRIPTION
Hello. I noticed a long time ago that the HTTP Client buffers the loaded documents into RAM because curl returns the response body as a string when the `curl_exec()` method is called.

This behavior sometimes leads to memory overflow and script crash.
Personally, it [affected](https://github.com/thephpleague/flysystem-webdav/issues/52) me when using the WebDAV protocol (downloading large files). At that time, i found a [workaround for myself](https://gist.github.com/roxblnfk/591c944a71e32cc39349a37f64b8d2ed). Today i want to share it with the community, as i see users encountering out of memory errors.

I wrote a test to load a document that exceeds the application's `memory_limit`.
In the current version of the code this test naturally fails with an error:
```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 48238592 bytes) in sabre\http\lib\Client.php on line 589
```
After the merger of this PR, this will be passed.

I have run tests in the `saber/dav` package. After a clean installation, they did not work for me. With this PR, the test resuts is no different. It seems to me that backward compatibility for `saber/dav` has been preserved, but we should move towards getting rid of the use of deprecated methods.
From my position, the best solution would be to remove the obsolete code altogether and release a major version, but here you know better.