### PR TITLE
Ensure $_SERVER keys are read as strings.

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -154,6 +154,7 @@ class Sapi
         $hostName = 'localhost';
 
         foreach ($serverArray as $key => $value) {
+            $key = string($key);
             switch ($key) {
                 case 'SERVER_PROTOCOL':
                     if ('HTTP/1.0' === $value) {

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -154,7 +154,7 @@ class Sapi
         $hostName = 'localhost';
 
         foreach ($serverArray as $key => $value) {
-            $key = string($key);
+            $key = (string) $key;
             switch ($key) {
                 case 'SERVER_PROTOCOL':
                     if ('HTTP/1.0' === $value) {


### PR DESCRIPTION
When looping over an array with foreach php will automatically convert
numeric values to integers. Since the key here is passed to substr it
has to be of string type. This commit explicitly convert the key value
to string.

I found this by accident by setting "env[LC_MESSAGES] = C.UTF-8" in my php-fpm pool configuration. For whatever reason this translated to '"6" => "C.UTF-8' in the $_SERVER array, which caused tons of headache while troubleshooting my nextcloud installation. I havn't really verified if this is the only bug of this kind (I fixed my problem by updating the php-configuration), but since I found this bug I thought I could at least report it.