### PR TITLE
Fix deprecated usages on PHP 8.1

### DIFF
--- a/lib/Message.php
+++ b/lib/Message.php
@@ -88,7 +88,7 @@ abstract class Message implements MessageInterface
          * @var string|int|null
          */
         $contentLength = $this->getHeader('Content-Length');
-        if (is_int($contentLength) || ctype_digit($contentLength)) {
+        if (null !== $contentLength && (is_int($contentLength) || ctype_digit($contentLength))) {
             return stream_get_contents($body, (int) $contentLength);
         }
 

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -149,7 +149,7 @@ class Response extends Message implements ResponseInterface
      */
     public function setStatus($status)
     {
-        if (ctype_digit($status) || is_int($status)) {
+        if (is_int($status) || ctype_digit($status)) {
             $statusCode = $status;
             $statusText = self::$statusCodes[$status] ?? 'Unknown';
         } else {


### PR DESCRIPTION
Fixes following errors encounterd on a PHP 8.1 RC environment.

```
==> Error E_DEPRECATED in ... generated by file /var/glpi/vendor/sabre/http/lib/Message.php on line 91:
ctype_digit(): Argument of type null will be interpreted as string in the future
==> Error E_DEPRECATED in ... generated by file /var/glpi/vendor/sabre/http/lib/Response.php on line 152:
ctype_digit(): Argument of type int will be interpreted as string in the future
```