### PR TITLE
Add resource size to CURL options in client

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -383,7 +383,9 @@ class Client extends EventEmitter
                     // reason.
                     $settings[CURLOPT_PUT] = true;
                     $settings[CURLOPT_INFILE] = $body;
-                    $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
+                    if ($bodyStat !== false && array_key_exists('size', $bodyStat)) {
+                        $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
+                    }
                 } else {
                     // For security we cast this to a string. If somehow an array could
                     // be passed here, it would be possible for an attacker to use @ to

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -376,11 +376,14 @@ class Client extends EventEmitter
             default:
                 $body = $request->getBody();
                 if (is_resource($body)) {
+                    $bodyStat = fstat($body);
+
                     // This needs to be set to PUT, regardless of the actual
                     // method used. Without it, INFILE will be ignored for some
                     // reason.
                     $settings[CURLOPT_PUT] = true;
-                    $settings[CURLOPT_INFILE] = $request->getBody();
+                    $settings[CURLOPT_INFILE] = $body;
+                    $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
                 } else {
                     // For security we cast this to a string. If somehow an array could
                     // be passed here, it would be possible for an attacker to use @ to


### PR DESCRIPTION
In order to make WebDAV client work with Nextcloud server, CURL request needs to have filesize information. Otherwise file is created, but with 0 bytes size.

Also, fixes #153