### PR TITLE
Add resource size to CURL options in client

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -383,7 +383,9 @@ class Client extends EventEmitter
                     // reason.
                     $settings[CURLOPT_PUT] = true;
                     $settings[CURLOPT_INFILE] = $body;
-                    $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
+                    if ($bodyStat !== false && array_key_exists('size', $bodyStat)) {
+                        $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
+                    }
                 } else {
                     // For security we cast this to a string. If somehow an array could
                     // be passed here, it would be possible for an attacker to use @ to

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -376,11 +376,14 @@ class Client extends EventEmitter
             default:
                 $body = $request->getBody();
                 if (is_resource($body)) {
+                    $bodyStat = fstat($body);
+
                     // This needs to be set to PUT, regardless of the actual
                     // method used. Without it, INFILE will be ignored for some
                     // reason.
                     $settings[CURLOPT_PUT] = true;
-                    $settings[CURLOPT_INFILE] = $request->getBody();
+                    $settings[CURLOPT_INFILE] = $body;
+                    $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
                 } else {
                     // For security we cast this to a string. If somehow an array could
                     // be passed here, it would be possible for an attacker to use @ to

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -383,7 +383,7 @@ class Client extends EventEmitter
                     // reason.
                     $settings[CURLOPT_PUT] = true;
                     $settings[CURLOPT_INFILE] = $body;
-                    if ($bodyStat !== false && array_key_exists('size', $bodyStat)) {
+                    if (false !== $bodyStat && array_key_exists('size', $bodyStat)) {
                         $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
                     }
                 } else {

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -96,8 +96,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = new ClientMock();
 
+        $fileContent = 'booh';
         $h = fopen('php://memory', 'r+');
-        fwrite($h, 'booh');
+        fwrite($h, $fileContent);
         $request = new Request('PUT', 'http://example.org/', ['X-Foo' => 'bar'], $h);
 
         $settings = [
@@ -105,6 +106,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 CURLOPT_HEADER => true,
                 CURLOPT_PUT => true,
                 CURLOPT_INFILE => $h,
+                CURLOPT_INFILESIZE => strlen($fileContent),
                 CURLOPT_NOBODY => false,
                 CURLOPT_CUSTOMREQUEST => 'PUT',
                 CURLOPT_HTTPHEADER => ['X-Foo: bar'],


### PR DESCRIPTION
This is a rebased version of PR #172 (That PR comes from a `master` branch on the fork, so I can't easily push to update that)