### PR TITLE
Fix encoding detection on PHP 8.1

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -404,11 +404,9 @@ function decodePath(string $path): string
 function decodePathSegment(string $path): string
 {
     $path = rawurldecode($path);
-    $encoding = mb_detect_encoding($path, ['UTF-8', 'ISO-8859-1']);
 
-    switch ($encoding) {
-        case 'ISO-8859-1':
-            $path = utf8_encode($path);
+    if (!mb_check_encoding($path, 'UTF-8') && mb_check_encoding($path, 'ISO-8859-1')) {
+        $path = mb_convert_encoding($path, 'UTF-8', 'ISO-8859-1');
     }
 
     return $path;

--- a/tests/HTTP/URLUtilTest.php
+++ b/tests/HTTP/URLUtilTest.php
@@ -72,6 +72,25 @@ class URLUtilTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @depends testDecode
+     */
+    public function testDecodeSlavicWords()
+    {
+        $words = [
+            'Ostroměr',
+            'Šventaragis',
+            'Świętopełk',
+            'Dušan',
+            'Živko',
+        ];
+        foreach ($words as $word) {
+            $str = rawurlencode($word);
+            $newStr = decodePath($str);
+            $this->assertEquals($word, $newStr);
+        }
+    }
+
+    /**
      * @depends testDecodeUmlaut
      */
     public function testDecodeUmlautLatin1()


### PR DESCRIPTION
Use mb_check_encoding to detect encoding as mb_detect_encoding is misbehaving under PHP 8.1.
Also use mb_convert_encoding instead of utf8_encode as it’s getting deprecated in PHP 8.2.
Fixes https://github.com/sabre-io/http/issues/181