### PR TITLE
Remove 4GB file size workaround for 32bit OS / Stream Videos on IOS

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -89,8 +89,6 @@ class Sapi
         if (null !== $contentLength) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && 'stream' == get_resource_type($body)) {
-                if (PHP_INT_SIZE > 4) {
-                    // use the dedicated function on 64 Bit systems
                     // a workaround to make PHP more possible to use mmap based copy, see https://github.com/sabre-io/http/pull/119
                     $left = (int) $contentLength;
                     // copy with 4MiB chunks
@@ -119,12 +117,6 @@ class Sapi
                         }
                         $left -= $copied;
                     }
-                } else {
-                    // workaround for 32 Bit systems to avoid stream_copy_to_stream
-                    while (!feof($body)) {
-                        fwrite($output, fread($body, 8192));
-                    }
-                }
             } else {
                 fwrite($output, $body, (int) $contentLength);
             }

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -89,34 +89,34 @@ class Sapi
         if (null !== $contentLength) {
             $output = fopen('php://output', 'wb');
             if (is_resource($body) && 'stream' == get_resource_type($body)) {
-                    // a workaround to make PHP more possible to use mmap based copy, see https://github.com/sabre-io/http/pull/119
-                    $left = (int) $contentLength;
-                    // copy with 4MiB chunks
-                    $chunk_size = 4 * 1024 * 1024;
-                    stream_set_chunk_size($output, $chunk_size);
-                    // If this is a partial response, flush the beginning bytes until the first position that is a multiple of the page size.
-                    $contentRange = $response->getHeader('Content-Range');
-                    // Matching "Content-Range: bytes 1234-5678/7890"
-                    if (null !== $contentRange && preg_match('/^bytes\s([0-9]+)-([0-9]+)\//i', $contentRange, $matches)) {
-                        // 4kB should be the default page size on most architectures
-                        $pageSize = 4096;
-                        $offset = (int) $matches[1];
-                        $delta = ($offset % $pageSize) > 0 ? ($pageSize - $offset % $pageSize) : 0;
-                        if ($delta > 0) {
-                            $left -= stream_copy_to_stream($body, $output, min($delta, $left));
-                        }
+                // a workaround to make PHP more possible to use mmap based copy, see https://github.com/sabre-io/http/pull/119
+                $left = (int) $contentLength;
+                // copy with 4MiB chunks
+                $chunk_size = 4 * 1024 * 1024;
+                stream_set_chunk_size($output, $chunk_size);
+                // If this is a partial response, flush the beginning bytes until the first position that is a multiple of the page size.
+                $contentRange = $response->getHeader('Content-Range');
+                // Matching "Content-Range: bytes 1234-5678/7890"
+                if (null !== $contentRange && preg_match('/^bytes\s([0-9]+)-([0-9]+)\//i', $contentRange, $matches)) {
+                    // 4kB should be the default page size on most architectures
+                    $pageSize = 4096;
+                    $offset = (int) $matches[1];
+                    $delta = ($offset % $pageSize) > 0 ? ($pageSize - $offset % $pageSize) : 0;
+                    if ($delta > 0) {
+                        $left -= stream_copy_to_stream($body, $output, min($delta, $left));
                     }
-                    while ($left > 0) {
-                        $copied = stream_copy_to_stream($body, $output, min($left, $chunk_size));
-                        // stream_copy_to_stream($src, $dest, $maxLength) must return the number of bytes copied or false in case of failure
-                        // But when the $maxLength is greater than the total number of bytes remaining in the stream,
-                        // It returns the negative number of bytes copied
-                        // So break the loop in such cases.
-                        if ($copied <= 0) {
-                            break;
-                        }
-                        $left -= $copied;
+                }
+                while ($left > 0) {
+                    $copied = stream_copy_to_stream($body, $output, min($left, $chunk_size));
+                    // stream_copy_to_stream($src, $dest, $maxLength) must return the number of bytes copied or false in case of failure
+                    // But when the $maxLength is greater than the total number of bytes remaining in the stream,
+                    // It returns the negative number of bytes copied
+                    // So break the loop in such cases.
+                    if ($copied <= 0) {
+                        break;
                     }
+                    $left -= $copied;
+                }
             } else {
                 fwrite($output, $body, (int) $contentLength);
             }


### PR DESCRIPTION
Like described in https://github.com/sabre-io/http/issues/108 there are still issues, when 
- Nextcloud is running on 32 Bit-OS (like mine running on RPI)
- iOS-Clients want to access Movies

The workaround initially introduced with https://github.com/sabre-io/http/pull/74  is not necessary anymore. By the time the 64-Bit-Coding has been improved to serve 4MB chunks that don't hurt on 32Bit-systems.

There are similar recommendations (like https://help.nextcloud.com/t/ios-nextcloud-client-does-not-play-videos/99790/4 ) to step into the 64Bit-Coding _always_ by changing >4 to >0

This Pull-Request simply deletes the separation of 64/32 Bitsystems