### PR TITLE
Install xdebug in CI so that all PHP unit tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype, curl, mbstring
+          extensions: ctype, curl, mbstring, xdebug
           coverage: ${{ matrix.coverage }}
           tools: composer
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        coverage: ['pcov']
+        coverage: ['xdebug']
         code-analysis: ['no']
         include:
           - php-versions: '7.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         code-analysis: ['no']
         include:
           - php-versions: '7.1'
-            coverage: 'none'
             code-analysis: 'yes'
     steps:
       - name: Checkout


### PR DESCRIPTION
Various tests are typically skipped in CI because of unit test code like:
```
        if (!function_exists('xdebug_get_headers')) {
            $this->markTestSkipped('XDebug needs to be installed for this test to run');
        }
```


```
PHPUnit 9.5.21 #StandWithUkraine
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
...............................................................  63 / 159 ( 39%)
............................................................... 126 / 159 ( 79%)
...SS.SSSSSSSSSSSSSSSSSSSS.......                               159 / 159 (100%)
Time: 00:00.423, Memory: 59.99 MB
OK, but incomplete, skipped, or risky tests!
Tests: 159, Assertions: 270, Skipped: 22.
Generating code coverage report in Clover XML format ... done [00:00.014]
```

It would be much nicer if all the tests run in CI.


But itg is not super-simple:
https://github.com/sabre-io/http/runs/7260954717?check_suite_focus=true
```
/usr/bin/bash /home/runner/work/_actions/shivammathur/setup-php/v2/src/scripts/run.sh
==> Setup PHP
✓ PHP Switched to PHP 7.4.30
==> Setup Extensions
✓ ctype Enabled
✓ curl Enabled
✓ mbstring Enabled
✓ xdebug Enabled
==> Setup Tools
✓ composer Added composer 2.3.9
==> Setup Coverage
✓ pcov.enabled=1 Added to php.ini
✓ coverage: pcov PCOV 1.0.11 enabled as coverage driver
```

I think that `pcov` interferes with `xdebug` and `function_exists('xdebug_get_headers')` returns false. Whereas locally (without pcov in the mix) I can:
```
$ sudo apt install php7.4-xdebug
...
$ composer phpunit
> phpunit --configuration tests/phpunit.xml
PHPUnit 9.5.21 #StandWithUkraine

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 159 ( 39%)
............................................................... 126 / 159 ( 79%)
.................................                               159 / 159 (100%)

Time: 00:01.591, Memory: 71.99 MB

OK (159 tests, 293 assertions)
```
and all tests run.

But we want all the tests to run, and to collect test coverage. Now to look at how to achieve that.