### PR TITLE
Allow testSendToGetLargeContent peak memory usage to be specified externally

### DIFF
--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -211,7 +211,8 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 
         // Allow the peak memory usage limit to be specified externally, if needed.
         // When running this test in different environments it may be appropriate to set a different limit.
-        $maxPeakMemoryUsage = \getenv('SABRE_HTTP_TEST_GET_LARGE_CONTENT_MAX_PEAK_MEMORY_USAGE');
+        $maxPeakMemoryUsageEnvVariable = 'SABRE_HTTP_TEST_GET_LARGE_CONTENT_MAX_PEAK_MEMORY_USAGE';
+        $maxPeakMemoryUsage = \getenv($maxPeakMemoryUsageEnvVariable);
         if (false === $maxPeakMemoryUsage) {
             $maxPeakMemoryUsage = 60 * pow(1024, 2);
         }
@@ -221,7 +222,11 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $response = $client->send($request);
 
         $this->assertEquals(200, $response->getStatus());
-        $this->assertLessThan((int) $maxPeakMemoryUsage, memory_get_peak_usage());
+        $this->assertLessThan(
+            (int) $maxPeakMemoryUsage,
+            memory_get_peak_usage(),
+            "Hint: you can adjust the max peak memory usage allowed for this test by defining env variable $maxPeakMemoryUsageEnvVariable to be the desired max bytes"
+        );
     }
 
     /**

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -209,12 +209,19 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             $this->markTestSkipped('Set an environment value BASEURL to continue');
         }
 
+        // Allow the peak memory usage limit to be specified externally, if needed.
+        // When running this test in different environments it may be appropriate to set a different limit.
+        $maxPeakMemoryUsage = \getenv('SABRE_HTTP_TEST_GET_LARGE_CONTENT_MAX_PEAK_MEMORY_USAGE');
+        if (false === $maxPeakMemoryUsage) {
+            $maxPeakMemoryUsage = 60 * pow(1024, 2);
+        }
+
         $request = new Request('GET', $url);
         $client = new Client();
         $response = $client->send($request);
 
         $this->assertEquals(200, $response->getStatus());
-        $this->assertLessThan(60 * pow(1024, 2), memory_get_peak_usage());
+        $this->assertLessThan((int) $maxPeakMemoryUsage, memory_get_peak_usage());
     }
 
     /**


### PR DESCRIPTION
See discussion https://github.com/sabre-io/dav/pull/1409#issuecomment-1185270940

The 'sabre/http' PHP unit tests are also run in the `sabre/dav` CI. The PHP environment is a bit "bigger" there, and `memory_get_peak_usage()` returns about 70MB, above the 60MB limit that the test allows.

This PR adds an env variable that can be defined to specify the peak memory usage that is allowed for the test. That will let us be more flexible in other CI.

I called it `SABRE_HTTP_TEST_GET_LARGE_CONTENT_MAX_PEAK_MEMORY_USAGE` - naming is hard, and I wanted a name that won't conflict with anything else in anyone's environment!