### PR TITLE
Fix typo in text of status code 203 'Non-Authoritative Information'

### DIFF
--- a/lib/Response.php
+++ b/lib/Response.php
@@ -25,7 +25,7 @@ class Response extends Message implements ResponseInterface
         200 => 'OK',
         201 => 'Created',
         202 => 'Accepted',
-        203 => 'Non-Authorative Information',
+        203 => 'Non-Authoritative Information',
         204 => 'No Content',
         205 => 'Reset Content',
         206 => 'Partial Content',


### PR DESCRIPTION
This typo is in a `public static` array. If HTTP status 203 is ever used/returned, then the typo-fix means that the associated will be slightly different. I guess nobody will depend on the typo "Non-Authorative"?