### PR TITLE
changelog and VERSION bump for 5.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+5.1.6 (2022-07-15)
+------------------
+
+* #187 Allow testSendToGetLargeContent peak memory usage to be specified externally (@phil-davis)
+* #188 Fix various small typos and grammar (@phil-davis)
+* #189 Fix typo in text of status code 203 'Non-Authoritative Information' (@phil-davis)
+
 5.1.5 (2022-07-09)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '5.1.5';
+    const VERSION = '5.1.6';
 }


### PR DESCRIPTION
Note: this release is primarily for PR #187 that adds flexibility to the unit test testSendToGetLargeContent so that it can be used more reliably in CI of `sabre/dav`

The changes to "real" code are mostly just typos and grammar that do not effect behavior.