### PR TITLE
Adjust type declarations a little bit

### DIFF
--- a/lib/Auth/Digest.php
+++ b/lib/Auth/Digest.php
@@ -40,7 +40,7 @@ class Digest extends AbstractAuth
     protected string $nonce;
     protected string $opaque;
     /**
-     * @var array<string, string>|bool
+     * @var array<int|string, string>|bool
      */
     protected $digestParts;
     protected string $A1;
@@ -189,7 +189,7 @@ class Digest extends AbstractAuth
      *
      * This method returns false if an incomplete digest was supplied
      *
-     * @return bool|array<string, int>
+     * @return false|array<int|string, mixed>
      */
     protected function parseDigest(string $digest)
     {

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -153,8 +153,8 @@ class Response extends Message implements ResponseInterface
                 $statusCode,
                 $statusText
             ) = explode(' ', $status, 2);
-            $statusCode = (int) $statusCode;
         }
+        $statusCode = (int) $statusCode;
         if ($statusCode < 100 || $statusCode > 999) {
             throw new \InvalidArgumentException('The HTTP status code must be exactly 3 digits');
         }

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -84,6 +84,8 @@ class Response extends Message implements ResponseInterface
 
     /**
      * HTTP status code.
+     *
+     * @var int<100, 999>
      */
     protected int $status;
 

--- a/tests/HTTP/ResponseTest.php
+++ b/tests/HTTP/ResponseTest.php
@@ -21,6 +21,14 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Where\'s my money?', $response->getStatusText());
     }
 
+    public function testSetStatusWithoutText(): void
+    {
+        $response = new Response();
+        $response->setStatus('402');
+        $this->assertEquals(402, $response->getStatus());
+        $this->assertEquals('Payment Required', $response->getStatusText());
+    }
+
     public function testInvalidStatus(): void
     {
         $this->expectException('InvalidArgumentException');


### PR DESCRIPTION
1) `digestParts` should be a bit more flexible

2) Response.php `setStatus` - be more careful to set the variable to `int` - specially in the case when the passed-in value is `ctype_digit` (e.g. "200" "402" ...)

I tried phpstan level 7 and noticed these things that looked like they can and should be fixed/adjusted. Level 7 also reports a lot of stuff about PHP functions that can return "something or false" like `string|false` - there are quite a few places where the (remote) possibility of `false` is not checked. We put the return value straight into `string` (or whatever). In most of those cases, there is no good explanation for when `false` can happen - "the internet broke", "the operating system fell to pieces"... So I am not planning to analyze each one and work out some path to handle the occurrence of `false`. Those things could happen already with the code, they are not regressions, and if/when they happen, some unexpected code path is being taken until, presumably, something falls over. Now they are likely to fall over earlier, because PHP will complain if the code tries to assign `false` to some `string $var` - and the PHP error and traceback will point more directly the the point in the code where the problem first happened.