### PR TITLE
Cleanup grammar in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@ ChangeLog
 
 * Added: Asynchronous HTTP client. See examples/asyncclient.php.
 * Fixed: Issue #4: Don't escape colon (:) when it's not needed.
-* Fixed: Fixed a bug in the content negotation script.
+* Fixed: Fixed a bug in the content negotiation script.
 * Fixed: Fallback for when CURLOPT_POSTREDIR is not defined (mainly for hhvm).
 * Added: The Request and Response object now have a `__toString()` method that
   serializes the objects into a standard HTTP message. This is mainly for

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sabre/http
 
 This library provides a toolkit to make working with the [HTTP protocol](https://tools.ietf.org/html/rfc2616) easier.
 
-Most PHP scripts run within a HTTP request but accessing information about the
+Most PHP scripts run within an HTTP request but accessing information about the
 HTTP request is cumbersome at least.
 
 There's bad practices, inconsistencies and confusion. This library is
@@ -57,7 +57,7 @@ This library came to existence in 2009, as a part of the [`sabre/dav`][2]
 project, which uses it heavily.
 
 It got split off into a separate library to make it easier to manage
-releases and hopefully giving it use outside of the scope of just `sabre/dav`.
+releases and hopefully giving it use outside the scope of just `sabre/dav`.
 
 Although completely independently developed, this library has a LOT of
 overlap with [Symfony's `HttpFoundation`][3].
@@ -221,7 +221,7 @@ $client->on('afterRequest', function($request, $response) {
 
 $client->on('error', function($request, $response, &$retry, $retryCount) {
 
-    // The error event is triggered for every response with a HTTP code higher
+    // The error event is triggered for every response with an HTTP code higher
     // than 399.
 
 });
@@ -527,7 +527,7 @@ function getHeaders();
 function getHeader($name);
 
 /**
- * Updates a HTTP header.
+ * Updates an HTTP header.
  *
  * The case-sensitivity of the name value must be retained as-is.
  *
@@ -559,7 +559,7 @@ function setHeaders(array $headers);
 function addHeaders(array $headers);
 
 /**
- * Removes a HTTP header.
+ * Removes an HTTP header.
  *
  * The specified header name must be treated as case-insensitive.
  * This method should return true if the header was successfully deleted,
@@ -672,7 +672,7 @@ function getHeaders();
 function getHeader($name);
 
 /**
- * Updates a HTTP header.
+ * Updates an HTTP header.
  *
  * The case-sensitivity of the name value must be retained as-is.
  *
@@ -704,7 +704,7 @@ function setHeaders(array $headers);
 function addHeaders(array $headers);
 
 /**
- * Removes a HTTP header.
+ * Removes an HTTP header.
  *
  * The specified header name must be treated as case-insensitive.
  * This method should return true if the header was successfully deleted,

--- a/examples/asyncclient.php
+++ b/examples/asyncclient.php
@@ -3,7 +3,7 @@
 /**
  * This example demonstrates the ability for clients to work asynchronously.
  *
- * By default up to 10 requests will be executed in parallel. HTTP connections
+ * By default, up to 10 requests will be executed in parallel. HTTP connections
  * are re-used and DNS is cached, all thanks to the power of curl.
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).

--- a/examples/client.php
+++ b/examples/client.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * This example shows how to make a HTTP request with the Request and Response
+ * This example shows how to make an HTTP request with the Request and Response
  * objects.
  *
  * @copyright Copyright (C) 2009-2015 fruux GmbH (https://fruux.com/).

--- a/lib/Auth/Basic.php
+++ b/lib/Auth/Basic.php
@@ -7,7 +7,7 @@ namespace Sabre\HTTP\Auth;
 /**
  * HTTP Basic authentication utility.
  *
- * This class helps you setup basic auth. The process is fairly simple:
+ * This class helps you set up basic auth. The process is fairly simple:
  *
  * 1. Instantiate the class.
  * 2. Call getCredentials (this will return null or a user/pass pair)

--- a/lib/Auth/Bearer.php
+++ b/lib/Auth/Bearer.php
@@ -7,7 +7,7 @@ namespace Sabre\HTTP\Auth;
 /**
  * HTTP Bearer authentication utility.
  *
- * This class helps you setup bearer auth. The process is fairly simple:
+ * This class helps you set up bearer auth. The process is fairly simple:
  *
  * 1. Instantiate the class.
  * 2. Call getToken (this will return null or a token as string)

--- a/lib/Auth/Digest.php
+++ b/lib/Auth/Digest.php
@@ -133,7 +133,7 @@ class Digest extends AbstractAuth
             if (!($this->qop & self::QOP_AUTHINT)) {
                 return false;
             }
-            // We need to add an md5 of the entire request body to the A2 part of the hash
+            // We need to add an MD5 of the entire request body to the A2 part of the hash
             $body = $this->request->getBody();
             $this->request->setBody($body);
             $A2 .= ':'.md5($body);

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -28,7 +28,7 @@ use Sabre\Uri;
  * The afterRequest event will be emitted after the request is completed
  * successfully.
  *
- * If a HTTP error is returned (status code higher than 399) the error event is
+ * If an HTTP error is returned (status code higher than 399) the error event is
  * triggered. It's possible using this event to retry the request, by setting
  * retry to true.
  *
@@ -53,7 +53,7 @@ class Client extends EventEmitter
     protected array $curlSettings = [];
 
     /**
-     * Whether exceptions should be thrown when a HTTP error is returned.
+     * Whether exceptions should be thrown when an HTTP error is returned.
      */
     protected bool $throwExceptions = false;
 
@@ -73,7 +73,7 @@ class Client extends EventEmitter
     public function __construct()
     {
         // See https://github.com/sabre-io/http/pull/115#discussion_r241292068
-        // Preserve compatibility for sub-classes that implements their own method `parseCurlResult`
+        // Preserve compatibility for sub-classes that implement their own method `parseCurlResult`
         $separatedHeaders = __CLASS__ === get_class($this);
 
         $this->curlSettings = [
@@ -99,7 +99,7 @@ class Client extends EventEmitter
     }
 
     /**
-     * Sends a request to a HTTP server, and returns a response.
+     * Sends a request to an HTTP server, and returns a response.
      */
     public function send(RequestInterface $request): ResponseInterface
     {
@@ -138,7 +138,7 @@ class Client extends EventEmitter
                     ++$redirects;
                 }
 
-                // This was a HTTP error
+                // This was an HTTP error
                 if ($code >= 400) {
                     $this->emit('error', [$request, $response, &$retry, $retryCount]);
                     $this->emit('error:'.$code, [$request, $response, &$retry, $retryCount]);
@@ -169,7 +169,7 @@ class Client extends EventEmitter
     }
 
     /**
-     * Sends a HTTP request asynchronously.
+     * Sends an HTTP request asynchronously.
      *
      * Due to the nature of PHP, you must from time to time poll to see if any
      * new responses came in.
@@ -391,7 +391,7 @@ class Client extends EventEmitter
                         $settings[CURLOPT_INFILESIZE] = $bodyStat['size'];
                     }
                 } else {
-                    // For security we cast this to a string. If somehow an array could
+                    // For security, we cast this to a string. If somehow an array could
                     // be passed here, it would be possible for an attacker to use @ to
                     // post local files.
                     $settings[CURLOPT_POSTFIELDS] = (string) $body;
@@ -461,7 +461,7 @@ class Client extends EventEmitter
      *                   STATUS_CURLERROR.
      *   * response - Response object. Only set if status is STATUS_SUCCESS, or
      *                STATUS_HTTPERROR.
-     *   * http_code - HTTP status code, as an int. Only set if Only set if
+     *   * http_code - HTTP status code, as an int. Only set if
      *                 status is STATUS_SUCCESS, or STATUS_HTTPERROR
      *
      * @param array<int, string> $headerLines
@@ -517,7 +517,7 @@ class Client extends EventEmitter
      *                   STATUS_CURLERROR.
      *   * response - Response object. Only set if status is STATUS_SUCCESS, or
      *                STATUS_HTTPERROR.
-     *   * http_code - HTTP status code, as an int. Only set if Only set if
+     *   * http_code - HTTP status code, as an int. Only set if
      *                 status is STATUS_SUCCESS, or STATUS_HTTPERROR
      *
      * @deprecated Use parseCurlResponse instead
@@ -597,7 +597,7 @@ class Client extends EventEmitter
     /**
      * Calls curl_exec.
      *
-     * This method exists so it can easily be overridden and mocked.
+     * This method exists so that it can easily be overridden and mocked.
      *
      * @param resource $curlHandle
      */
@@ -616,7 +616,7 @@ class Client extends EventEmitter
     /**
      * Returns a bunch of information about a curl request.
      *
-     * This method exists so it can easily be overridden and mocked.
+     * This method exists so that it can easily be overridden and mocked.
      *
      * @param resource $curlHandle
      *

--- a/lib/ClientHttpException.php
+++ b/lib/ClientHttpException.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Sabre\HTTP;
 
 /**
- * This exception represents a HTTP error coming from the Client.
+ * This exception represents an HTTP error coming from the Client.
  *
- * By default the Client will not emit these, this has to be explicitly enabled
+ * By default, the Client will not emit these, this has to be explicitly enabled
  * with the setThrowExceptions method.
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)

--- a/lib/HttpException.php
+++ b/lib/HttpException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sabre\HTTP;
 
 /**
- * An exception representing a HTTP error.
+ * An exception representing an HTTP error.
  *
  * This can be used as a generic exception in your application, if you'd like
  * to map HTTP errors to exceptions.

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -133,7 +133,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * Will return true or false, depending on if a HTTP header exists.
+     * Will return true or false, depending on if an HTTP header exists.
      */
     public function hasHeader(string $name): bool
     {
@@ -146,7 +146,7 @@ abstract class Message implements MessageInterface
      * The name must be treated as case-insensitive.
      * If the header does not exist, this method must return null.
      *
-     * If a header appeared more than once in a HTTP request, this method will
+     * If a header appeared more than once in an HTTP request, this method will
      * concatenate all the values with a comma.
      *
      * Note that this not make sense for all headers. Some, such as
@@ -165,7 +165,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * Returns a HTTP header as an array.
+     * Returns an HTTP header as an array.
      *
      * For every time the HTTP header appeared in the request or response, an
      * item will appear in the array.
@@ -186,7 +186,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * Updates a HTTP header.
+     * Updates an HTTP header.
      *
      * The case-sensitivity of the name value must be retained as-is.
      *
@@ -217,7 +217,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * Adds a HTTP header.
+     * Adds an HTTP header.
      *
      * This method will not overwrite any existing HTTP header, but instead add
      * another value. Individual values can be retrieved with
@@ -256,7 +256,7 @@ abstract class Message implements MessageInterface
     }
 
     /**
-     * Removes a HTTP header.
+     * Removes an HTTP header.
      *
      * The specified header name must be treated as case-insensitive.
      * This method should return true if the header was successfully deleted,

--- a/lib/MessageDecoratorTrait.php
+++ b/lib/MessageDecoratorTrait.php
@@ -76,7 +76,7 @@ trait MessageDecoratorTrait
     }
 
     /**
-     * Will return true or false, depending on if a HTTP header exists.
+     * Will return true or false, depending on if an HTTP header exists.
      */
     public function hasHeader(string $name): bool
     {
@@ -89,7 +89,7 @@ trait MessageDecoratorTrait
      * The name must be treated as case-insensitive.
      * If the header does not exist, this method must return null.
      *
-     * If a header appeared more than once in a HTTP request, this method will
+     * If a header appeared more than once in an HTTP request, this method will
      * concatenate all the values with a comma.
      *
      * Note that this not make sense for all headers. Some, such as
@@ -102,7 +102,7 @@ trait MessageDecoratorTrait
     }
 
     /**
-     * Returns a HTTP header as an array.
+     * Returns an HTTP header as an array.
      *
      * For every time the HTTP header appeared in the request or response, an
      * item will appear in the array.
@@ -115,7 +115,7 @@ trait MessageDecoratorTrait
     }
 
     /**
-     * Updates a HTTP header.
+     * Updates an HTTP header.
      *
      * The case-sensitivity of the name value must be retained as-is.
      *
@@ -144,7 +144,7 @@ trait MessageDecoratorTrait
     }
 
     /**
-     * Adds a HTTP header.
+     * Adds an HTTP header.
      *
      * This method will not overwrite any existing HTTP header, but instead add
      * another value. Individual values can be retrieved with
@@ -170,7 +170,7 @@ trait MessageDecoratorTrait
     }
 
     /**
-     * Removes a HTTP header.
+     * Removes an HTTP header.
      *
      * The specified header name must be treated as case-insensitive.
      * This method should return true if the header was successfully deleted,

--- a/lib/MessageInterface.php
+++ b/lib/MessageInterface.php
@@ -58,7 +58,7 @@ interface MessageInterface
     public function getHeaders(): array;
 
     /**
-     * Will return true or false, depending on if a HTTP header exists.
+     * Will return true or false, depending on if an HTTP header exists.
      */
     public function hasHeader(string $name): bool;
 
@@ -68,7 +68,7 @@ interface MessageInterface
      * The name must be treated as case-insensitive.
      * If the header does not exist, this method must return null.
      *
-     * If a header appeared more than once in a HTTP request, this method will
+     * If a header appeared more than once in an HTTP request, this method will
      * concatenate all the values with a comma.
      *
      * Note that this not make sense for all headers. Some, such as
@@ -78,7 +78,7 @@ interface MessageInterface
     public function getHeader(string $name): ?string;
 
     /**
-     * Returns a HTTP header as an array.
+     * Returns an HTTP header as an array.
      *
      * For every time the HTTP header appeared in the request or response, an
      * item will appear in the array.
@@ -90,7 +90,7 @@ interface MessageInterface
     public function getHeaderAsArray(string $name): array;
 
     /**
-     * Updates a HTTP header.
+     * Updates an HTTP header.
      *
      * The case-sensitivity of the name value must be retained as-is.
      *
@@ -113,7 +113,7 @@ interface MessageInterface
     public function setHeaders(array $headers): void;
 
     /**
-     * Adds a HTTP header.
+     * Adds an HTTP header.
      *
      * This method will not overwrite any existing HTTP header, but instead add
      * another value. Individual values can be retrieved with
@@ -133,7 +133,7 @@ interface MessageInterface
     public function addHeaders(array $headers): void;
 
     /**
-     * Removes a HTTP header.
+     * Removes an HTTP header.
      *
      * The specified header name must be treated as case-insensitive.
      * This method should return true if the header was successfully deleted,

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -151,10 +151,10 @@ class Request extends Message implements RequestInterface
      * If the full path is equal to the base url, this method will return an
      * empty string.
      *
-     * This method will also urldecode the path, and if the url was encoded as
+     * This method will also URL-decode the path, and if the url was encoded as
      * ISO-8859-1, it will convert it to UTF-8.
      *
-     * If the path is outside of the base url, a LogicException will be thrown.
+     * If the path is outside the base url, a LogicException will be thrown.
      */
     public function getPath(): string
     {

--- a/lib/RequestDecorator.php
+++ b/lib/RequestDecorator.php
@@ -110,10 +110,10 @@ class RequestDecorator implements RequestInterface
      * If the full path is equal to the base url, this method will return an
      * empty string.
      *
-     * This method will also urldecode the path, and if the url was encoded as
+     * This method will also URL-decode the path, and if the url was encoded as
      * ISO-8859-1, it will convert it to UTF-8.
      *
-     * If the path is outside of the base url, a LogicException will be thrown.
+     * If the path is outside the base url, a LogicException will be thrown.
      */
     public function getPath(): string
     {

--- a/lib/RequestInterface.php
+++ b/lib/RequestInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sabre\HTTP;
 
 /**
- * The RequestInterface represents a HTTP request.
+ * The RequestInterface represents an HTTP request.
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)
@@ -67,10 +67,10 @@ interface RequestInterface extends MessageInterface
      * If the full path is equal to the base url, this method will return an
      * empty string.
      *
-     * This method will also urldecode the path, and if the url was encoded as
+     * This method will also URL-decode the path, and if the url was encoded as
      * ISO-8859-1, it will convert it to UTF-8.
      *
-     * If the path is outside of the base url, a LogicException will be thrown.
+     * If the path is outside the base url, a LogicException will be thrown.
      */
     public function getPath(): string;
 

--- a/lib/ResponseInterface.php
+++ b/lib/ResponseInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sabre\HTTP;
 
 /**
- * This interface represents a HTTP response.
+ * This interface represents an HTTP response.
  *
  * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
  * @author Evert Pot (http://evertpot.com/)

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -57,7 +57,7 @@ class Sapi
     }
 
     /**
-     * Sends the HTTP response back to a HTTP client.
+     * Sends the HTTP response back to an HTTP client.
      *
      * This calls php's header() function and streams the body to php://output.
      */
@@ -164,7 +164,7 @@ class Sapi
                     $url = $value;
                     break;
 
-                    // These sometimes show up without a HTTP_ prefix
+                    // These sometimes show up without an HTTP_ prefix
                 case 'CONTENT_TYPE':
                     $headers['Content-Type'] = $value;
                     break;
@@ -204,7 +204,7 @@ class Sapi
 
                 default:
                     if ('HTTP_' === substr($key, 0, 5)) {
-                        // It's a HTTP header
+                        // It's an HTTP header
 
                         // Normalizing it to be prettier
                         $header = strtolower(substr($key, 5));

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -16,7 +16,7 @@ use DateTime;
  */
 
 /**
- * Parses a HTTP date-string.
+ * Parses an HTTP date-string.
  *
  * This method returns false if the date is invalid.
  *
@@ -97,7 +97,7 @@ function toDate(DateTime $dateTime): string
  * you can choose to emit 406 Not Acceptable.
  *
  * The method also accepts sending 'null' for the $acceptHeaderValue,
- * implying that no accept header was sent.
+ * implying that no accept-header was sent.
  *
  * @param array<mixed, mixed> $availableOptions
  */
@@ -272,7 +272,7 @@ REGEX;
 /**
  * This method splits up headers into all their individual values.
  *
- * A HTTP header may have more than one header, such as this:
+ * An HTTP header may have more than one header, such as this:
  *   Cache-Control: private, no-store
  *
  * Header values are always split with a comma.
@@ -368,7 +368,7 @@ function parseMimeType(string $str): array
 }
 
 /**
- * Encodes the path of a url.
+ * Encodes the path of a URL.
  *
  * slashes (/) are treated as path-separators.
  */
@@ -392,7 +392,7 @@ function encodePathSegment(string $pathSegment): string
 }
 
 /**
- * Decodes a url-encoded path.
+ * Decodes a URL-encoded path.
  */
 function decodePath(string $path): string
 {

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -543,7 +543,7 @@ class ClientMock extends Client
     /**
      * Returns a bunch of information about a curl request.
      *
-     * This method exists so it can easily be overridden and mocked.
+     * This method exists so that it can easily be overridden and mocked.
      *
      * @param resource $curlHandle
      */
@@ -563,7 +563,7 @@ class ClientMock extends Client
     /**
      * Calls curl_exec.
      *
-     * This method exists so it can easily be overridden and mocked.
+     * This method exists so that it can easily be overridden and mocked.
      *
      * @param resource $curlHandle
      */

--- a/tests/HTTP/URLUtilTest.php
+++ b/tests/HTTP/URLUtilTest.php
@@ -38,8 +38,8 @@ class URLUtilTest extends \PHPUnit\Framework\TestCase
 
         $newStr = encodePathSegment($str);
 
-        // Note: almost exactly the same as the last test, with the
-        // exception of the encoding of / (ascii code 2f)
+        // Note: almost exactly the same as the last test, except for
+        // the encoding of / (ascii code 2f)
         $this->assertEquals(
             '%00%01%02%03%04%05%06%07%08%09%0a%0b%0c%0d%0e%0f'.
             '%10%11%12%13%14%15%16%17%18%19%1a%1b%1c%1d%1e%1f'.


### PR DESCRIPTION
No functional change. This just cleans up some crud in comments that my IDE keeps telling me about. May as well do it so I don't have to see it any more.