### PR TITLE
Adjust code style to meet current php-cs-fixer

### DIFF
--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sabre\HTTP;
 
-use InvalidArgumentException;
-
 /**
  * PHP SAPI.
  *
@@ -222,11 +220,11 @@ class Sapi
         }
 
         if (null === $url) {
-            throw new InvalidArgumentException('The _SERVER array must have a REQUEST_URI key');
+            throw new \InvalidArgumentException('The _SERVER array must have a REQUEST_URI key');
         }
 
         if (null === $method) {
-            throw new InvalidArgumentException('The _SERVER array must have a REQUEST_METHOD key');
+            throw new \InvalidArgumentException('The _SERVER array must have a REQUEST_METHOD key');
         }
         $r = new Request($method, $url, $headers);
         $r->setHttpVersion($httpVersion);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -28,7 +28,7 @@ use DateTime;
  * See:
  *   http://tools.ietf.org/html/rfc7231#section-7.1.1.1
  *
- * @return bool|DateTime
+ * @return bool|\DateTime
  */
 function parseDate(string $dateString)
 {
@@ -64,7 +64,7 @@ function parseDate(string $dateString)
     }
 
     try {
-        return new DateTime($dateString, new \DateTimeZone('UTC'));
+        return new \DateTime($dateString, new \DateTimeZone('UTC'));
     } catch (\Exception $e) {
         return false;
     }
@@ -73,7 +73,7 @@ function parseDate(string $dateString)
 /**
  * Transforms a DateTime object to a valid HTTP/1.1 Date header value.
  */
-function toDate(DateTime $dateTime): string
+function toDate(\DateTime $dateTime): string
 {
     // We need to clone it, as we don't want to affect the existing
     // DateTime.

--- a/tests/HTTP/Auth/DigestTest.php
+++ b/tests/HTTP/Auth/DigestTest.php
@@ -42,7 +42,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
             $nc.':'.
             $cnonce.':'.
             'auth:'.
-            md5('GET'.':'.'/')
+            md5('GET:/')
         );
 
         $this->request->setMethod('GET');
@@ -71,7 +71,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
             $nc.':'.
             $cnonce.':'.
             'auth:'.
-            md5('GET'.':'.'/')
+            md5('GET:/')
         );
 
         $this->request->setMethod('GET');
@@ -107,7 +107,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
             $nc.':'.
             $cnonce.':'.
             'auth-int:'.
-            md5('POST'.':'.'/'.':'.md5('body'))
+            md5('POST:/:'.md5('body'))
         );
 
         $this->request->setMethod('POST');
@@ -135,7 +135,7 @@ class DigestTest extends \PHPUnit\Framework\TestCase
             $nc.':'.
             $cnonce.':'.
             'auth-int:'.
-            md5('POST'.':'.'/'.':'.md5('body'))
+            md5('POST:/:'.md5('body'))
         );
 
         $this->request->setMethod('POST');


### PR DESCRIPTION
php-cs-fixer is reporting these. I guess there has been a newer php-cs-fixer version released that is different.

It wants "root" classes and functions to use the leading `\` - `\DateTime`.

We could change some php-cs-fixer rule settings, but actually it is easy to accept these code-style changes.