### PR TITLE
fix "access array offset on value of type bool"

### DIFF
--- a/lib/Auth/Digest.php
+++ b/lib/Auth/Digest.php
@@ -123,9 +123,12 @@ class Digest extends AbstractAuth {
      * @return string
      */
     function getUsername() {
-
-        return $this->digestParts['username'];
-
+        if(isset($this->digestParts['username'])){
+            return $this->digestParts['username'];
+        }
+        // i want to return null, but unsure of the compliations of changing the return type to string|null
+        // future versions of this method returns null.
+        return "";
     }
 
     /**


### PR DESCRIPTION
trying to send the request
curl -X OPTIONS https://url/webdav/
to Sabre\dav 3.2.x will result in
<b>Warning</b>:  Trying to access array offset on value of type bool in <b>C:\xampp\htdocs\webdav\vendor\sabre\http\lib\Auth\Digest.php</b> on line <b>127</b><br />

- this is already fixed in newer versions of sabre/http, but i doubt Sabre\dav 3.2 will ever be upgraded beyond sabre\http 4.2.x,  and sabre\dav 3.2 is the current release version (dav 4.x isn't released yet)