### PR TITLE
Apply cs-fixer and phpstan changes to make CI pass

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -301,8 +301,6 @@ class Client extends EventEmitter
      * Adds a CURL setting.
      *
      * These settings will be included in every HTTP request.
-     *
-     * @param mixed $value
      */
     public function addCurlSetting(int $name, $value): void
     {
@@ -340,7 +338,7 @@ class Client extends EventEmitter
      *
      * @var resource|null
      */
-    private $curlHandle = null;
+    private $curlHandle;
 
     /**
      * Handler for curl_multi requests.
@@ -349,7 +347,7 @@ class Client extends EventEmitter
      *
      * @var resource|null
      */
-    private $curlMultiHandle = null;
+    private $curlMultiHandle;
 
     /**
      * Has a list of curl handles, as well as their associated success and

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -22,7 +22,7 @@ abstract class Message implements MessageInterface
      *
      * @var resource|string|callable|null
      */
-    protected $body = null;
+    protected $body;
 
     /**
      * Contains the list of HTTP headers.

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -101,7 +101,7 @@ class Response extends Message implements ResponseInterface
      * @param array<string, mixed>|null     $headers
      * @param resource|string|callable|null $body
      */
-    public function __construct($status = 500, ?array $headers = null, $body = null)
+    public function __construct($status = 500, array $headers = null, $body = null)
     {
         if (null !== $status) {
             $this->setStatus($status);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -168,9 +168,9 @@ function negotiateContentType(?string $acceptHeaderValue, array $availableOption
 
             // Does this entry win?
             if (
-                ($proposal['quality'] > $lastQuality) ||
-                ($proposal['quality'] === $lastQuality && $specificity > $lastSpecificity) ||
-                ($proposal['quality'] === $lastQuality && $specificity === $lastSpecificity && $optionIndex < $lastOptionIndex)
+                ($proposal['quality'] > $lastQuality)
+                || ($proposal['quality'] === $lastQuality && $specificity > $lastSpecificity)
+                || ($proposal['quality'] === $lastQuality && $specificity === $lastSpecificity && $optionIndex < $lastOptionIndex)
             ) {
                 $lastQuality = $proposal['quality'];
                 $lastSpecificity = $specificity;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,7 @@ parameters:
     path: lib/Client.php
   -
     message: "#^Left side of || is always false.$#"
-    count: 1
+    count: 2
     path: lib/Client.php
   -
     message: "#^Strict comparison using === between null and array<string, mixed> will always evaluate to false.$#"


### PR DESCRIPTION
cs-fixer now wants to cleanup more "useless" code fragments.
- declaring a parameter as "mixed" in PHPdoc is useless (adds no information)
- initializing variables to `null` is useless (they are already initialized to `null` by PHP anyway)
- `?array $headers = null` - the question mark is useless - the `= null` means that you can pass `null` or "unspecified"
- `phpstan` finds an extra occurrence of "#^Left side of || is always false.$#"