### PR TITLE
Prepare for release 7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 =========
 
+7.0.2 (2023-06-27)
+------------------
+* #203 Add phpstan phpunit strict-rules (@phil-davis)
+
 7.0.1 (2023-06-26)
 ------------------
 * #207 fix: handle client disconnect properly with ignore_user_abort true (@kesselb)

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    public const VERSION = '7.0.1';
+    public const VERSION = '7.0.2';
 }


### PR DESCRIPTION
This should not break any consumer. For anyone already using v7, it will report some types more accurately and so their consumer-code will be better analyzed by phpstan.

Note: most consumers will currently be using `sabre/http` along with `sabre/dav` and other sabre-io components. So the dependency requirements of the current `sabre/dav` 4.4.0 will pull in `sabre/http` 5.1.7 anyway. So there are probably not many projects using `sabre/http` major version 7 yet anyway.

Eventually I will work through the type-declarations and phpstan level 9 throughout the sabre-io repos - I have some work in `vobject` that I need to get back to, and then try the main `sabre/dav` repo. And then we can do a set of major releases of all that...