### PR TITLE
Improve CURLOPT_HTTPHEADER Setting Assignment

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -405,7 +405,10 @@ class Client extends EventEmitter
                 $nHeaders[] = $key.': '.$value;
             }
         }
-        $settings[CURLOPT_HTTPHEADER] = $nHeaders;
+        
+        if(!empty($nHeaders)){
+            $settings[CURLOPT_HTTPHEADER] = $nHeaders;
+        }
         $settings[CURLOPT_URL] = $request->getUrl();
         // FIXME: CURLOPT_PROTOCOLS is currently unsupported by HHVM
         if (defined('CURLOPT_PROTOCOLS')) {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -405,8 +405,8 @@ class Client extends EventEmitter
                 $nHeaders[] = $key.': '.$value;
             }
         }
-        
-        if(!empty($nHeaders)){
+
+        if ([] !== $nHeaders) {
             $settings[CURLOPT_HTTPHEADER] = $nHeaders;
         }
         $settings[CURLOPT_URL] = $request->getUrl();

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -34,6 +34,33 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
 
+    public function testCreateCurlSettingsHTTPHeader(): void
+    {
+        $client = new ClientMock();
+        $header = [
+            'Authorization: Bearer 12345',
+        ];
+        $client->addCurlSetting(CURLOPT_POSTREDIR, 0);
+        $client->addCurlSetting(CURLOPT_HTTPHEADER, $header);
+
+        $request = new Request('GET', 'http://example.org/');
+
+        $settings = [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADER => true,
+            CURLOPT_POSTREDIR => 0,
+            CURLOPT_HTTPHEADER => ['Authorization: Bearer 12345'],
+            CURLOPT_NOBODY => false,
+            CURLOPT_URL => 'http://example.org/',
+            CURLOPT_CUSTOMREQUEST => 'GET',
+            CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+        ];
+
+        self::assertEquals($settings, $client->createCurlSettingsArray($request));
+    }
+
     public function testCreateCurlSettingsArrayHEAD(): void
     {
         $client = new ClientMock();


### PR DESCRIPTION
This PR code prevents potential issues that could arise from setting CURLOPT_HTTPHEADER with an empty value. By adding a conditional check, we ensure that we only assign meaningful and valid header values.
```
        $settings[CURLOPT_HTTPHEADER] = $nHeaders;
```
```
        if (!empty($nHeaders)) {
            $settings[CURLOPT_HTTPHEADER] = $nHeaders;
        }
```

## Testing:
- Ensure that when $nHeaders contains valid header values, they are assigned to $settings[CURLOPT_HTTPHEADER].
- When $nHeaders is empty, $settings[CURLOPT_HTTPHEADER] should not be set or altered.