### PR TITLE
Remove HHVM special comments and test code

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -410,11 +410,9 @@ class Client extends EventEmitter
             $settings[CURLOPT_HTTPHEADER] = $nHeaders;
         }
         $settings[CURLOPT_URL] = $request->getUrl();
-        // FIXME: CURLOPT_PROTOCOLS is currently unsupported by HHVM
         if (defined('CURLOPT_PROTOCOLS')) {
             $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
         }
-        // FIXME: CURLOPT_REDIR_PROTOCOLS is currently unsupported by HHVM
         if (defined('CURLOPT_REDIR_PROTOCOLS')) {
             $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
         }

--- a/tests/HTTP/ClientTest.php
+++ b/tests/HTTP/ClientTest.php
@@ -22,14 +22,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 CURLOPT_URL => 'http://example.org/',
                 CURLOPT_CUSTOMREQUEST => 'GET',
                 CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             ];
-
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -74,14 +69,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 CURLOPT_HTTPHEADER => ['X-Foo: bar'],
                 CURLOPT_URL => 'http://example.org/',
                 CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             ];
-
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -107,14 +97,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 CURLOPT_NOBODY => false,
                 CURLOPT_URL => 'http://example.org/',
                 CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             ];
-
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -139,14 +124,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 CURLOPT_HTTPHEADER => ['X-Foo: bar'],
                 CURLOPT_URL => 'http://example.org/',
                 CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             ];
-
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }
@@ -165,14 +145,9 @@ class ClientTest extends \PHPUnit\Framework\TestCase
                 CURLOPT_HTTPHEADER => ['X-Foo: bar'],
                 CURLOPT_URL => 'http://example.org/',
                 CURLOPT_USERAGENT => 'sabre-http/'.Version::VERSION.' (http://sabre.io/)',
+                CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             ];
-
-        // FIXME: CURLOPT_PROTOCOLS and CURLOPT_REDIR_PROTOCOLS are currently unsupported by HHVM
-        // at least if this unit test fails in the future we know it is :)
-        if (false === defined('HHVM_VERSION')) {
-            $settings[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-            $settings[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
-        }
 
         self::assertEquals($settings, $client->createCurlSettingsArray($request));
     }


### PR DESCRIPTION
We don't have any tests related to HHVM. So remove the special checks from the test code, and remove comments about HHVM.