### PR TITLE
[5.1] Prepare 5.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+5.1.9 (2023-08-17)
+------------------
+
+* #223 skip testParseMimeTypeOnInvalidMimeType (@phil-davis)
+
 5.1.8 (2023-08-17)
 ------------------
 

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -16,5 +16,5 @@ class Version
     /**
      * Full version number.
      */
-    const VERSION = '5.1.8';
+    const VERSION = '5.1.9';
 }


### PR DESCRIPTION
We need to release this test-only change, because the released code of major version 5 contains the tests as well as the code - a piece of history. And we want to keep doing that for compatibility.

`sabre/dav` also runs the `sabre/http` unit tests in its CI (another piece of history) and the HTTP test problem in issue #222 prevents unit tests from running properly to completion. For example:
https://github.com/sabre-io/dav/actions/runs/5889816355/job/15983958426?pr=1483
```
PHPUnit 9.6.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.33 with Xdebug 3.1.6
Configuration: tests/phpunit.xml
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.............................................................   61 / 1805 (  3%)
.....array(1) {
  [0]=>
  string(17) "invalid_mime_type"
}
```


Only 61 of 1805 test cases ran, but the CI gave it a pass.

We need to sort that out, and is a way to do it without refactoring the whole "system".
