### PR TITLE
[5.1] Enhance tests/bootstrap.php to find autoloader in more environments

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,4 +7,11 @@ date_default_timezone_set('UTC');
 ini_set('error_reporting', (string) (E_ALL | E_STRICT | E_DEPRECATED));
 
 // Composer autoloader
-include __DIR__.'/../vendor/autoload.php';
+if (file_exists(__DIR__.'/../vendor/autoload.php')) {
+    include __DIR__.'/../vendor/autoload.php';
+} else {
+    // We may be running as a dependency inside some other repo.
+    // So we are probably in vendor/sabre/http/tests of that repo.
+    // Go up 3 levels to find autoload.php
+    include __DIR__.'/../../../autoload.php';
+}


### PR DESCRIPTION
Fixes https://github.com/sabre-io/dav/issues/1484

When the sabre/http unit tests are run from inside the sabre/dav repo, the https://github.com/sabre-io/http/blob/master/tests/www/connection_aborted.php code includes https://github.com/sabre-io/http/blob/master/tests/bootstrap.php

https://github.com/sabre-io/http/blob/master/tests/bootstrap.php tries to find an `autoloader.php` to run, but in that environment, `autoloader.php` is actually found a few levels up - see the comments in the code for details.

This enhancement to https://github.com/sabre-io/http/blob/master/tests/bootstrap.php lets `connection_aborted.php` find `HTTP\Response()` and so it runs properly.

The test that makes use of it now passes even when run from inside the `sabre/dav` repo - I have tried manually on my laptop.

This is all a bit of a pain, but anyway, we may as well patch it up for now.