### PR TITLE
chore: use php-cs-fixer 3.51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.3 || ^3.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.49",
+        "friendsofphp/php-cs-fixer": "^3.51",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.3 || ^3.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.38",
+        "friendsofphp/php-cs-fixer": "^3.49",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpstan/phpstan-strict-rules": "^1.5",

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -177,7 +177,7 @@ class Client extends EventEmitter
      * After calling sendAsync, you must therefore occasionally call the poll()
      * method, or wait().
      */
-    public function sendAsync(RequestInterface $request, callable $success = null, callable $error = null): void
+    public function sendAsync(RequestInterface $request, ?callable $success = null, ?callable $error = null): void
     {
         $this->emit('beforeRequest', [$request]);
         $this->sendAsyncInternal($request, $success, $error);

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -101,7 +101,7 @@ class Response extends Message implements ResponseInterface
      * @param array<string, mixed>|null     $headers
      * @param resource|string|callable|null $body
      */
-    public function __construct($status = 500, array $headers = null, $body = null)
+    public function __construct($status = 500, ?array $headers = null, $body = null)
     {
         if (null !== $status) {
             $this->setStatus($status);


### PR DESCRIPTION
php-cs-fixer 3.49 (or some recent minor release) wants to use the `?` (nullable) syntax on optional parameters.
That syntax has been supported for quite a while since PHP https://www.php.net/manual/en/migration71.new-features.php

In the cases here, as well as the default value of the parameter being `null`, the `?` explicitly allows the caller to pass the value `null` if they want.

This seems reasonable, I don't see how it can break any existing usage.