### PR TITLE
chore: stop exporting php-cs-fixer config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /.gitattributes export-ignore
 /.gitignore     export-ignore
 /.php_cs.dist   export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /CHANGELOG.md   export-ignore
 /README.md      export-ignore
 /phpstan.neon   export-ignore


### PR DESCRIPTION
Same as was done in https://github.com/sabre-io/xml/pull/282

And delete the unused bin directory, same as https://github.com/sabre-io/xml/pull/281