### PR TITLE
tool changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,16 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
         coverage: ['xdebug']
+        code-style: ['yes']
         code-analysis: ['no']
         include:
           - php-versions: '7.4'
+            coverage: 'xdebug'
+            code-style: 'yes'
+            code-analysis: 'yes'
+          - php-versions: '8.4'
+            coverage: 'xdebug'
+            code-style: 'yes'
             code-analysis: 'yes'
     steps:
       - name: Checkout
@@ -45,8 +52,8 @@ jobs:
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
-        if: matrix.code-analysis == 'yes'
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        if: matrix.code-style == 'yes'
+        run: PHP_CS_FIXER_IGNORE_ENV=true php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)
         if: matrix.code-analysis == 'yes'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,6 +10,10 @@ $config->getFinder()
 $config->setRules([
     '@PSR1' => true,
     '@Symfony' => true,
+    'nullable_type_declaration' => [
+        'syntax' => 'question_mark',
+    ],
+    'nullable_type_declaration_for_default_null_value' => true,
 ]);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.3 || ^3.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^3.56",
+        "friendsofphp/php-cs-fixer": "^3.64",
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-phpunit": "^1.4",
         "phpstan/phpstan-strict-rules": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
             "phpstan analyse lib tests"
         ],
         "cs-fixer": [
-            "php-cs-fixer fix"
+            "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix"
         ],
         "phpunit": [
             "phpunit --configuration tests/phpunit.xml"

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -474,7 +474,7 @@ class Client extends EventEmitter
         list(
             $curlInfo,
             $curlErrNo,
-            $curlErrMsg
+            $curlErrMsg,
         ) = $this->curlStuff($curlHandle);
 
         if (0 !== $curlErrNo) {
@@ -531,7 +531,7 @@ class Client extends EventEmitter
         list(
             $curlInfo,
             $curlErrNo,
-            $curlErrMsg
+            $curlErrMsg,
         ) = $this->curlStuff($curlHandle);
 
         if (0 !== $curlErrNo) {

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -153,7 +153,7 @@ class Response extends Message implements ResponseInterface
         } else {
             list(
                 $statusCode,
-                $statusText
+                $statusText,
             ) = explode(' ', $status, 2);
         }
         $statusCode = (int) $statusCode;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,11 +15,23 @@ parameters:
     count: 6
     path: lib/Client.php
   -
+    message: "#^Else branch is unreachable because ternary operator condition is always true.$#"
+    count: 1
+    path: lib/Auth/Digest.php
+  -
+    message: "#^Strict comparison using !== between '' and non-empty-string will always evaluate to true.$#"
+    count: 1
+    path: lib/Auth/Digest.php
+  -
     message: "#^Casting to string something that's already string.$#"
     count: 1
     path: lib/Sapi.php
   -
     message: "#^Strict comparison using === between null and array<string, mixed> will always evaluate to false.$#"
+    count: 1
+    path: lib/functions.php
+  -
+    message: "#^Offset 'value' on array.* in isset\\(\\) always exists and is not nullable.$#"
     count: 1
     path: lib/functions.php
   -


### PR DESCRIPTION
- apply php-cs-fixer 3.64 changes
- add PHP 8.4 to CI
- ignore phpstan reports about superfluous code - these are about code paths that phpstan knows are never taken. They do no harm. For now, I will ignore these phpstan reports, and leave the "protective but unnecessary" code

There are no more "Implicitly marking parameter $xxx as nullable is deprecated" code to be fixed.

The executable code changes in this PR are just what php-cs-fixer 3.64 wants to do.

I can make a new 7.0.4 release after this, that officially supports PHP 8.4
