### PR TITLE
pin php-cs-fixer to 3.63.2 in 5.1 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "sabre/uri"    : "^2.0"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "~2.17.1||^3.63",
+        "friendsofphp/php-cs-fixer": "~2.17.1||3.63.2",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.6"
     },


### PR DESCRIPTION
We still support PHP 7.1 7.2 7.3 here, and that uses the old php-cs-fixer v2.
The new php-cs-fixer 3.64 wants to make changes to trailing-comma in `list()` - we want to avoid doing that in this old 5.1 branch, because php-cs-fixer v2 does not like it.